### PR TITLE
Add basic size inference.

### DIFF
--- a/parser_parts/any_bytes.rb
+++ b/parser_parts/any_bytes.rb
@@ -1,10 +1,6 @@
 class AnyBytes
   def initialize(size)
-    if size
-      @size = size
-    else
-      @size = ConstSize.new 1
-    end
+    @size = ConstSize.new Bytes.new (size ? size : 1)
   end
 
   def duplicate
@@ -13,6 +9,9 @@ class AnyBytes
 
   def requirements
     []
+  end
+
+  def resolve(arg)
   end
 
   def match(bytes)
@@ -31,9 +30,13 @@ class AnyBytes
     @data
   end
 
+  def size_of
+    @size
+  end
+
   def clone
     puts "Cloning!"
-    AnyBytes.new ConstSize.new @size
+    AnyBytes.new size.value
   end
 
   def resolved

--- a/parser_parts/bit_body.rb
+++ b/parser_parts/bit_body.rb
@@ -27,6 +27,10 @@ class BitBody
     true
   end
 
+  def size_of
+    ConstSize.new Bits.new @body.length
+  end
+
   def to_s
     @body.to_s
   end

--- a/parser_parts/bits.rb
+++ b/parser_parts/bits.rb
@@ -9,10 +9,22 @@ class Bits
   end
 
   def initialize(size)
-    @size = size
+    @size = size || 1
   end
 
   def value
     @size.value
+  end
+
+  def +(other)
+    Bits.new (@size + other.bit_size)
+  end
+
+  def size
+    @size
+  end
+
+  def bit_size
+    @size
   end
 end

--- a/parser_parts/byte_body.rb
+++ b/parser_parts/byte_body.rb
@@ -62,6 +62,10 @@ class ByteBody
     "#{prefix}#{value}"
   end
 
+  def size_of
+    ConstSize.new Bytes.new 1
+  end
+
   def to_s
     "Literal value #{@byte.to_s} [specified as #{@byte.to_s(@base)} base #{@base}]"
   end

--- a/parser_parts/bytes.rb
+++ b/parser_parts/bytes.rb
@@ -11,11 +11,30 @@ class Bytes
   end
 
   def initialize(size)
-    @size = size || ConstSize.new(1)
+    @size = size || 1
   end
 
   def value
     @size.value
+  end
+
+  def +(other)
+    case other
+    when Bytes
+      Bytes.new(@size + other.size)
+    when Bits
+      Bits.new(bit_size + other.size)
+    else
+      throw "Unhandlable size #{other}"
+    end
+  end
+
+  def bit_size
+    @size * 8
+  end
+
+  def size
+    @size
   end
 
   def to_s

--- a/parser_parts/conjunction.rb
+++ b/parser_parts/conjunction.rb
@@ -35,6 +35,10 @@ class Conjunction
     end
   end
 
+  def size_of
+    @a.size_of + @b.size_of
+  end
+
   def to_s
     "(#{@a} followed by #{@b})"
   end

--- a/parser_parts/const_size.rb
+++ b/parser_parts/const_size.rb
@@ -1,13 +1,17 @@
 class ConstSize
-  def initialize(number)
-    @value = number.to_i
+  def initialize(value)
+    @value = value
   end
 
   def value
-    @value.to_i
+    @value
   end
 
   def to_s
     @value.to_s
+  end
+
+  def +(other)
+    ConstSize.new(other.value + @value)
   end
 end

--- a/parser_parts/disjunction.rb
+++ b/parser_parts/disjunction.rb
@@ -21,6 +21,10 @@ class Disjunction
     @b.resolve(arg)
   end
 
+  def size_of
+    @b.size_of
+  end
+
   def match(bytes)
     a_match = @a.match(bytes)
     if a_match

--- a/parser_parts/num_rule.rb
+++ b/parser_parts/num_rule.rb
@@ -45,6 +45,10 @@ class NumRule
   def resolve(arg)
   end
 
+  def size_of
+    ConstSize.new Bytes.new @bytes.length
+  end
+
   def match(bytes)
     for i in 0..@bytes.length
       if @bytes[i] != bytes.next

--- a/parser_parts/rule.rb
+++ b/parser_parts/rule.rb
@@ -8,6 +8,10 @@ class Rule
     Rule.new @name, @body.duplicate
   end
 
+  def infer_size
+    @body.infer_size
+  end
+
   def resolved
     @body.resolved
   end
@@ -30,6 +34,10 @@ class Rule
 
   def matched
     @body.matched
+  end
+
+  def size_of
+    @body.size_of
   end
 
   def to_s

--- a/parser_parts/rule_body.rb
+++ b/parser_parts/rule_body.rb
@@ -6,7 +6,6 @@ class RuleBody
     @size = size
     @body = body
     if not @body
-      puts "No body present, size of data to match for this rule is #{@size}"
       if @size.unit == Bits.unit
         @body = AnyBits.new @size
       elsif @size.unit == Bytes.unit
@@ -15,8 +14,11 @@ class RuleBody
         raise "Cannot handle unit #{@size.unit}"
       end
     end
+  end
+
+  def infer_size
     if not @size
-      puts "Must infer a size for #{body}"
+      @size = @body.size_of
     end
   end
 
@@ -38,6 +40,10 @@ class RuleBody
 
   def match(bytes)
     @body.match(bytes.mark)
+  end
+
+  def size_of
+    @body.size_of
   end
 
   def matched

--- a/parser_parts/rule_reference.rb
+++ b/parser_parts/rule_reference.rb
@@ -43,6 +43,10 @@ class RuleReference
     @rule.match(bytes)
   end
 
+  def size_of
+    @rule.size_of
+  end
+
   def to_s
     if not @rule
       "(Unresolved reference to rule #{@name})"

--- a/parser_parts/str_rule.rb
+++ b/parser_parts/str_rule.rb
@@ -18,6 +18,10 @@ class StrRule
   def resolve(arg)
   end
 
+  def size_of
+    ConstSize.new Bytes.new @matchStr.length
+  end
+
   def match(bytes)
     for i in 0..@matchStr.length - 1
       if bytes.eof

--- a/parser_parts/variable_binding.rb
+++ b/parser_parts/variable_binding.rb
@@ -29,6 +29,10 @@ class VariableBinding
     @body.requirements
   end
 
+  def size_of
+    @body.size_of
+  end
+
   def duplicate
     VariableBinding.new @name, @body
   end

--- a/poggler.rtlr
+++ b/poggler.rtlr
@@ -89,7 +89,6 @@ size_t <-
   ~'bit' size_multiple? { Bits.new _[0] } /
   ~'byte' size_multiple? { Bytes.new _[0] } /
   name size_multiple? {
-    puts "Thing named " + _[0]
     Prim.new _[0], _[1]
   }
 size_multiple <- ~'{' size_expr ~'}' { Size.new _ }
@@ -121,12 +120,8 @@ str2 <- ~'"' escaped_char* ~'"' {
   _
 }
 escaped_char <-
-  '\\\\' /
-  '"' /
-  "'" /
-  "!" /
-  " " /
-  ALNUM
+  GRAPH /
+  SPACE
 
 lit_byte <- @('0x' XDIGIT XDIGIT)
 lit_num <- @(DIGIT+) { _.to_i }


### PR DESCRIPTION
sizing is sloppy; since rule references cause a duplicate to be constructed, resolving `root` does not resolve referenced rules. temporary workaround is to resolve all rules by name so all rules have a size, but in the future I'll be looking to reduce duplication on rules and size information.
