### PR TITLE
Size inference fix

### DIFF
--- a/parser_parts/bits.rb
+++ b/parser_parts/bits.rb
@@ -14,12 +14,12 @@ class Bits
 
   def +(other)
     return other unless other.const
-    Bits.new (@size.force + other.bits)
+    Bits.new ConstSize.new (@size.force + other.bits)
   end
 
   def *(other)
     return other unless other.const
-    Bits.new (@size.force * other)
+    Bits.new ConstSize.new (@size.force * other)
   end
 
   def const

--- a/parser_parts/bytes.rb
+++ b/parser_parts/bytes.rb
@@ -1,4 +1,4 @@
-require_relative '../sizes/const_size'
+require_relative './const_size'
 
 class Bytes
   @@unit = "bytes"

--- a/parser_parts/bytes.rb
+++ b/parser_parts/bytes.rb
@@ -1,4 +1,4 @@
-require_relative './const_size'
+require_relative '../sizes/const_size'
 
 class Bytes
   @@unit = "bytes"
@@ -39,7 +39,7 @@ class Bytes
   end
 
   def *(other)
-    Bytes.new(@size * other)
+    Bytes.new ConstSize.new(@size * other)
   end
 
   def size

--- a/parser_parts/bytes.rb
+++ b/parser_parts/bytes.rb
@@ -30,9 +30,9 @@ class Bytes
     return self unless const
     case other
     when Bytes
-      Bytes.new(bytes + other.bytes)
+      Bytes.new ConstSize.new(bytes + other.bytes)
     when Bits
-      Bits.new(bits + other.bits)
+      Bits.new ConstSize.new(bits + other.bits)
     else
       throw "Unhandlable size #{other}"
     end

--- a/parser_parts/components.rb
+++ b/parser_parts/components.rb
@@ -9,7 +9,7 @@ class Components
   @rules_by_name
 
   def initialize(first, rest)
-    @debug = true
+    @debug = false
 
     @rules_by_name = {}
     rest.unshift first

--- a/parser_parts/components.rb
+++ b/parser_parts/components.rb
@@ -9,6 +9,8 @@ class Components
   @rules_by_name
 
   def initialize(first, rest)
+    @debug = true
+
     @rules_by_name = {}
     rest.unshift first
     @rules = rest
@@ -41,7 +43,12 @@ class Components
   end
 
   def infer_sizes
-    @rules.each { |rule| rule.infer_size }
+    @rules.each { |rule|
+      if @debug
+        puts "Inferring size for #{rule}"
+      end
+      rule.infer_size
+    }
   end
 
   def check_sizes


### PR DESCRIPTION
Solves the issue brought up in #11. Root cause was not wrapping sizes in a `ConstSize`, causing invocations of `value` on a bare FixNum.