### PR TITLE
Mark at start of disjunction match

### DIFF
--- a/parser_parts/primitives/disjunction.rb
+++ b/parser_parts/primitives/disjunction.rb
@@ -9,6 +9,7 @@ class Disjunction
   end
 
   def match(bytes)
+    bytes.mark
     a_match = @a.match(bytes)
     if a_match
       true


### PR DESCRIPTION
Addresses the issue raised by #14. The lack of marking meant that when a disjunction had to backtrack it would shift nil into `@pointer`, eventually possibly causing an indexing to `nil`.