### PR TITLE
Don't directly point to rtlr script

### DIFF
--- a/gen_poggle.sh
+++ b/gen_poggle.sh
@@ -1,4 +1,4 @@
 #! /bin/sh
-../rattler/bin/rtlr poggler.rtlr -o poggler_parser.rb -f
+rtlr poggler.rtlr -o poggler_parser.rb -f
 REPLACEALL="Dir[File.join(File.dirname(__FILE__), 'parser_parts', '**', '*.rb')].each {|file| require file }"
 sed -i "s/^.*REPLACEME.$/$REPLACEALL/" poggler_parser.rb


### PR DESCRIPTION
This allows rtlr to be anywhere in `PATH`, not just adjacent to the poggle work dir. I know better, really!